### PR TITLE
fix: Prefix shell with `/bin/` when modifying

### DIFF
--- a/mod/cmds/modify/user/user.go
+++ b/mod/cmds/modify/user/user.go
@@ -160,6 +160,8 @@ func createModifyUserRecord(conn *ldap.Connection, records *ldapv3.SearchResult,
 				if !funcs.I.IsInList(conn.Config.DefaultValues.ValidShells, valueEntered) {
 					funcs.P.PrintRed("\t\tInvalid shell was given, it will be ignored\n")
 					valueEntered = ""
+				} else {
+					valueEntered = "/bin/" + valueEntered
 				}
 			}
 


### PR DESCRIPTION
The `modify` operation doesn't prefix the `/bin` when the user `shell` is modified.